### PR TITLE
Replace broken apt-get sources

### DIFF
--- a/scripts/base.sh
+++ b/scripts/base.sh
@@ -2,5 +2,7 @@
 
 set -x
 
+sed 's@http://us-east-1\.ec2\.archive\.ubuntu\.com/@http://old-releases.ubuntu.com/@' -i /etc/apt/sources.list
 apt-get -y update
+apt-get -y upgrade
 apt-get -y install language-pack-en git curl wget python-stdeb devscripts


### PR DESCRIPTION
archive.ubuntu.com was migrated to old-releases.ubuntu.com so the additional command replaces it in the sources.list file as the build would break when apt-get was unable to find any packages.